### PR TITLE
[Bugfix] Work around for the issues in design explorer

### DIFF
--- a/src/components/TPS6208x.stanza
+++ b/src/components/TPS6208x.stanza
@@ -79,7 +79,9 @@ public pcb-component component (pn:TPS6208x-PN):
   property(self.Vin-MIN) = 2.3
 
   property(self.V-REF) = min-typ-max(0.438, 0.45, 0.462) ; Volts
-  property(self.I-REF) = typ-max(10.0e-9, 100.0e-9) ; Amps
+  ; property(self.I-REF) = typ-max(10.0e-9, 100.0e-9) ; Amps
+  ; Bug in Design Explorer calling this to fatal
+  property(self.I-REF) = min-typ-max(10.0e-9, 10.0e-9, 100.0e-9) ; Amps
 
   property(self.R-Discharge) = switch(pn):
     TPS62080ADSG: min-typ-max(25.0, 40.0, 65.0)

--- a/src/components/TPS6293x.stanza
+++ b/src/components/TPS6293x.stanza
@@ -113,8 +113,10 @@ public pcb-component component (pn:TPS6293x-PN):
   property(self.Ton-MAX) = 7.0e-6 ; Seconds
   property(self.Toff-MIN) = 140.0e-9 ; Seconds
 
-  property(self.V-EN-RISE) = typ-max(1.21, 1.28)
-  property(self.V-EN-FALL) = min-typ(1.1, 1.17)
+  ; property(self.V-EN-RISE) = typ-max(1.21, 1.28)
+  ; Bug in design explorer causes this to fatal
+  property(self.V-EN-RISE) = min-typ-max(1.21, 1.21, 1.28)
+  property(self.V-EN-FALL) = min-typ-max(1.1, 1.17, 1.17)
 
 doc: \<DOC>
 Compute the Frequency for a given RT pull-down resistor


### PR DESCRIPTION
This was causing failures in design explorer because design explorer expects a fully specified toleranced.